### PR TITLE
Previous version error solved

### DIFF
--- a/prerequisites/install_docker.sh
+++ b/prerequisites/install_docker.sh
@@ -22,7 +22,7 @@ set -e
 SCRIPT_COMMIT_SHA="93d2499759296ac1f9c510605fef85052a2c32be"
 
 # strip "v" prefix if present
-VERSION="20.10.12"
+VERSION="20.10.14"
 
 # The channel to install from:
 #   * nightly


### PR DESCRIPTION
When we used the command as sudo prerequisites/install_docker.sh it was giving error as ERROR: '20.10.12' not found amongst apt-cache madison results This was because of the version problem which is solved now.